### PR TITLE
fix: paddings on block details page

### DIFF
--- a/src/views/blockDetails/styles.module.css
+++ b/src/views/blockDetails/styles.module.css
@@ -1,21 +1,22 @@
 .pd-block-details {
-  @apply md:grid-cols-[theme(width.56)_1fr] font-geist grid ;
+  @apply md:grid-cols-[theme(width.56)_1fr] font-geist grid;
   @apply border-b border-dev-white-600 dark:border-dev-black-900;
   @apply hover:bg-dev-purple-100 dark:hover:bg-dev-purple-900;
   @apply transition-[background] duration-300;
+  @apply pb-2 sm:pb-0;
+
+  > p {
+    @apply font-body2-bold py-2;
+  }
+
+  > div {
+    @apply gap-2 font-body2-bold font-geist pb-2;
+  }
 
   > p,
   > div {
     @apply flex items-center;
-    @apply py-2 px-4 break-all sm:py-4 sm:pl-6;
-  }
-
-  > p {
-    @apply font-body2-bold;
-  }
-
-  > div {
-    @apply gap-2 font-body2-bold font-geist;
+    @apply px-4 break-all sm:pl-6 sm:py-4;
   }
 }
 


### PR DESCRIPTION
In this PR I have:

- fixed the padding between all rows in the block details page on mobile resolution;
- fixed the padding between the details in the block details page on mobile resolution;