### PR TITLE
chore(ui): swap positions of 'Default' and 'Custom' buttons in snippet select dropdown

### DIFF
--- a/src/views/codeEditor/components/selectExample/index.tsx
+++ b/src/views/codeEditor/components/selectExample/index.tsx
@@ -124,11 +124,6 @@ export const SelectExample = () => {
           )}
 
         >
-          <div data-title="Custom">
-            <li className="font-geist text-dev-white-1000 font-body1-regular dark:text-dev-black-300">
-              No examples found
-            </li>
-          </div>
           <div data-title="Default">
             <PDScrollArea
               verticalScrollClassNames="py-4"
@@ -165,6 +160,11 @@ export const SelectExample = () => {
                 }
               </ul>
             </PDScrollArea>
+          </div>
+          <div data-title="Custom">
+            <li className="font-geist text-dev-white-1000 font-body1-regular dark:text-dev-black-300">
+              No examples found
+            </li>
           </div>
         </Tabs>
       </div>


### PR DESCRIPTION
This PR updates the dropdown menu by swapping the positions of the 'Default' and 'Custom' buttons. 

- No functional changes were made, only the button order within the snippet select dropdown was modified
