### PR TITLE
feat: include the default extrinsics on the latest blocks list

### DIFF
--- a/src/utils/papi/index.ts
+++ b/src/utils/papi/index.ts
@@ -119,7 +119,7 @@ export const subscribeToBestBlocks = ({
       Promise.allSettled(promises).then((results) => {
         results.forEach((blockData) => {
           if (blockData.status === 'fulfilled') {
-            const blockExtrinsics = (blockData?.value.body?.extrinsics?.slice(2) ?? [])
+            const blockExtrinsics = (blockData?.value.body?.extrinsics ?? [])
               .reverse()
               .map((extrinsic) => {
                 const { id, blockNumber, extrinsicData, timestamp, isSuccess } = extrinsic;

--- a/src/views/explorer/components/extrinsicsList/index.tsx
+++ b/src/views/explorer/components/extrinsicsList/index.tsx
@@ -66,7 +66,7 @@ export const ExtrinsicsList = polymorphicComponent<'div'>((_props, ref) => {
 
   useEffect(() => {
     const extrinsics = Array.from(blocksData.values())
-      .flatMap((block) => block?.extrinsics ?? [])
+      .flatMap((block) => (block?.extrinsics?.slice(0, -2) ?? []))
       .reverse();
 
     setSignedExtrinsics(extrinsics);

--- a/src/views/signedExtrinsics/index.tsx
+++ b/src/views/signedExtrinsics/index.tsx
@@ -65,7 +65,7 @@ const SignedExtrinsics = () => {
 
   useEffect(() => {
     const extrinsics = Array.from(blocksData.values())
-      .flatMap((block) => block?.extrinsics ?? [])
+      .flatMap((block) => block?.extrinsics?.slice(0, -2) ?? [])
       .reverse();
 
     setSignedExtrinsics(extrinsics);


### PR DESCRIPTION
This update ensures that default extrinsics are now included when displaying blocks in the latest blocks scroll area.