### PR TITLE
Improvement/block details mobile tables

### DIFF
--- a/src/views/blockDetails/blockBody/index.tsx
+++ b/src/views/blockDetails/blockBody/index.tsx
@@ -89,7 +89,7 @@ export const BlockBody = (props: BlockBodyProps) => {
         initialTab={initialTab}
         onChange={setInitialTab}
         refContainer={refContainer}
-        tabClassName="px-2 py-2 mb-5"
+        tabClassName="px-2 py-2 mb-5 sticky left-0 last:left-24 sm:relative sm:last:left-0"
         unmountOnHide={false}
       >
         <div
@@ -173,7 +173,7 @@ export const BlockBody = (props: BlockBodyProps) => {
             bodyData.extrinsics.length > 3 && (
               <div className="flex justify-center">
                 <button
-                  className="mt-4 font-geist font-body2-bold"
+                  className="my-4 font-geist font-body2-bold sm:mb-0"
                   data-type="extrinsic"
                   onClick={handleShowMore}
                 >
@@ -246,7 +246,7 @@ export const BlockBody = (props: BlockBodyProps) => {
           {bodyData.events.length > 3 && (
             <div className="flex justify-center">
               <button
-                className="mt-4 font-geist font-body2-bold"
+                className="my-4 font-geist font-body2-bold sm:mb-0 sm:mt-4"
                 data-type="event"
                 onClick={handleShowMore}
               >

--- a/src/views/blockDetails/blockBody/index.tsx
+++ b/src/views/blockDetails/blockBody/index.tsx
@@ -246,7 +246,7 @@ export const BlockBody = (props: BlockBodyProps) => {
           {bodyData.events.length > 3 && (
             <div className="flex justify-center">
               <button
-                className="my-4 font-geist font-body2-bold sm:mb-0 sm:mt-4"
+                className="my-4 font-geist font-body2-bold sm:mb-0"
                 data-type="event"
                 onClick={handleShowMore}
               >

--- a/src/views/blockDetails/blockBody/index.tsx
+++ b/src/views/blockDetails/blockBody/index.tsx
@@ -28,7 +28,15 @@ interface BlockBodyProps {
 }
 
 export const BlockBody = (props: BlockBodyProps) => {
-  const { bodyData, blockNumber, blockTimestamp, showMore, selectedTab, onTabChange } = props;
+  const {
+    bodyData,
+    blockNumber,
+    blockTimestamp,
+    showMore,
+    selectedTab,
+    onTabChange,
+  } = props;
+
   const [
     JSONViewerModal,
     toggleVisibility,
@@ -80,7 +88,7 @@ export const BlockBody = (props: BlockBodyProps) => {
         <div
           data-title="Extrinsics"
         >
-          <table className="mb-4 w-full">
+          <table className="mb-2 w-full">
             <colgroup>
               <col className="min-w-28" />
               <col className="min-w-24" />
@@ -158,7 +166,7 @@ export const BlockBody = (props: BlockBodyProps) => {
         <div
           data-title="Events"
         >
-          <table className="mb-4 w-full">
+          <table className="mb-2 w-full">
             <colgroup>
               <col className="min-w-28" />
               <col className="min-w-36" />

--- a/src/views/blockDetails/blockBody/index.tsx
+++ b/src/views/blockDetails/blockBody/index.tsx
@@ -22,10 +22,13 @@ interface BlockBodyProps {
   bodyData: IMappedBlockBody;
   blockNumber: number;
   blockTimestamp: number;
+  showMore: boolean;
+  selectedTab: 'extrinsics' | 'events';
+  onTabChange: (tab: 'extrinsics' | 'events') => void;
 }
 
 export const BlockBody = (props: BlockBodyProps) => {
-  const { bodyData, blockNumber, blockTimestamp } = props;
+  const { bodyData, blockNumber, blockTimestamp, showMore, selectedTab, onTabChange } = props;
   const [
     JSONViewerModal,
     toggleVisibility,
@@ -37,21 +40,16 @@ export const BlockBody = (props: BlockBodyProps) => {
     modalData,
     setModalData,
   ] = useState<IMappedBlockEvent | IBlockExtrinsic | null>(null);
-  const [
-    initialTab,
-    setInitialTab,
-  ] = useState(0);
-  const [
-    showMoreExtrinsics,
-    setShowMoreExtrinsics,
-  ] = useState(false);
-  const [
-    showMoreEvents,
-    setShowMoreEvents,
-  ] = useState(false);
 
-  const visibleExtrinsics = showMoreExtrinsics ? bodyData.extrinsics : bodyData.extrinsics.slice(0, 3);
-  const visibleEvents = showMoreEvents ? bodyData.events : bodyData.events.slice(0, 3);
+  const visibleExtrinsics = showMore ? bodyData.extrinsics : bodyData.extrinsics.slice(0, 3);
+  const visibleEvents = showMore ? bodyData.events : bodyData.events.slice(0, 3);
+
+  const tabIndex = selectedTab === 'extrinsics' ? 0 : 1;
+
+  const handleOnTabChange = useCallback(
+    (index: number) => onTabChange(index === 0 ? 'extrinsics' : 'events'),
+    [onTabChange],
+  );
 
   const handleOpenModal = useCallback(async (e: React.MouseEvent<HTMLTableRowElement>) => {
     const type = e.currentTarget.getAttribute('data-type');
@@ -70,24 +68,11 @@ export const BlockBody = (props: BlockBodyProps) => {
     bodyData.events,
   ]);
 
-  const handleShowMore = useCallback((e: React.MouseEvent) => {
-    const type = e.currentTarget.getAttribute('data-type');
-    if (type === 'extrinsic') {
-      setShowMoreExtrinsics(!showMoreExtrinsics);
-    } else if (type === 'event') {
-      setShowMoreEvents(!showMoreEvents);
-    }
-
-  }, [
-    showMoreEvents,
-    showMoreExtrinsics,
-  ]);
-
   return (
     <div className="grid gap-4 overflow-auto">
       <Tabs
-        initialTab={initialTab}
-        onChange={setInitialTab}
+        initialTab={tabIndex}
+        onChange={handleOnTabChange}
         refContainer={refContainer}
         tabClassName="px-2 py-2 mb-5 sticky left-0 last:left-24 sm:relative sm:last:left-0"
         unmountOnHide={false}
@@ -95,7 +80,7 @@ export const BlockBody = (props: BlockBodyProps) => {
         <div
           data-title="Extrinsics"
         >
-          <table className="w-full">
+          <table className="mb-4 w-full">
             <colgroup>
               <col className="min-w-28" />
               <col className="min-w-24" />
@@ -169,24 +154,11 @@ export const BlockBody = (props: BlockBodyProps) => {
               }
             </tbody>
           </table>
-          {
-            bodyData.extrinsics.length > 3 && (
-              <div className="flex justify-center">
-                <button
-                  className="my-4 font-geist font-body2-bold sm:mb-0"
-                  data-type="extrinsic"
-                  onClick={handleShowMore}
-                >
-                  {showMoreExtrinsics ? 'Show Less' : 'Show More'}
-                </button>
-              </div>
-            )
-          }
         </div>
         <div
           data-title="Events"
         >
-          <table className="w-full">
+          <table className="mb-4 w-full">
             <colgroup>
               <col className="min-w-28" />
               <col className="min-w-36" />
@@ -243,17 +215,6 @@ export const BlockBody = (props: BlockBodyProps) => {
               }
             </tbody>
           </table>
-          {bodyData.events.length > 3 && (
-            <div className="flex justify-center">
-              <button
-                className="my-4 font-geist font-body2-bold sm:mb-0"
-                data-type="event"
-                onClick={handleShowMore}
-              >
-                {showMoreEvents ? 'Show Less' : 'Show More'}
-              </button>
-            </div>
-          )}
         </div>
       </Tabs>
       <JSONViewerModal

--- a/src/views/blockDetails/components/expandButton/index.tsx
+++ b/src/views/blockDetails/components/expandButton/index.tsx
@@ -1,0 +1,23 @@
+interface IExpandButtonProps {
+  isExpanded: boolean;
+  onToggle: () => void;
+  itemType: 'extrinsics' | 'events';
+}
+
+const ExpandButton = (props: IExpandButtonProps) => {
+  const { isExpanded, onToggle, itemType } = props;
+
+  return (
+    <div className="flex justify-center">
+      <button
+        className="font-geist font-body2-bold"
+        data-type={itemType}
+        onClick={onToggle}
+      >
+        {isExpanded ? `Show Less` : `Show More`}
+      </button>
+    </div>
+  );
+};
+
+export default ExpandButton;

--- a/src/views/blockDetails/components/expandButton/index.tsx
+++ b/src/views/blockDetails/components/expandButton/index.tsx
@@ -2,15 +2,21 @@ interface IExpandButtonProps {
   isExpanded: boolean;
   onToggle: () => void;
   itemType: 'extrinsics' | 'events';
+  className: string;
 }
 
 const ExpandButton = (props: IExpandButtonProps) => {
-  const { isExpanded, onToggle, itemType } = props;
+  const {
+    isExpanded,
+    onToggle,
+    itemType,
+    className,
+  } = props;
 
   return (
     <div className="flex justify-center">
       <button
-        className="font-geist font-body2-bold"
+        className={className}
         data-type={itemType}
         onClick={onToggle}
       >

--- a/src/views/blockDetails/index.tsx
+++ b/src/views/blockDetails/index.tsx
@@ -1,4 +1,5 @@
 import {
+  useCallback,
   useEffect,
   useMemo,
   useState,
@@ -12,6 +13,7 @@ import { useStoreChain } from '@stores';
 import { getBlockExplorerLink } from '@utils/explorer';
 import { formatNumber } from '@utils/helpers';
 import { getBlockDetailsWithRawClient } from '@utils/rpc/getBlockDetails';
+import ExpandButton from '@views/blockDetails/components/expandButton';
 import { useDynamicBuilder } from 'src/hooks/useDynamicBuilder';
 
 import { BlockBody } from './blockBody';
@@ -51,6 +53,23 @@ const BlockDetails = () => {
     blockData,
     setBlockData,
   ] = useState<IMappedBlock>();
+  const [
+    showMore,
+    setShowMore,
+  ] = useState(false);
+  const [
+    selectedTab,
+    setSelectedTab,
+  ] = useState<'extrinsics' | 'events'>('extrinsics');
+
+  const handleExpandButtonClick = useCallback(() => {
+    setShowMore((prev) => !prev);
+  }, []);
+
+  const handleTabChange = useCallback((tab: 'extrinsics' | 'events') => {
+    setSelectedTab(tab);
+    setShowMore(false);
+  }, []);
 
   useEffect(() => {
     void (async () => {
@@ -137,6 +156,14 @@ const BlockDetails = () => {
         blockNumber={blockData.header.number}
         blockTimestamp={blockData.header.timestamp}
         bodyData={blockData.body}
+        onTabChange={handleTabChange}
+        selectedTab={selectedTab}
+        showMore={showMore}
+      />
+      <ExpandButton
+        isExpanded={showMore}
+        itemType={selectedTab}
+        onToggle={handleExpandButtonClick}
       />
       <div className="flex justify-center gap-6 md:hidden">
         {

--- a/src/views/blockDetails/index.tsx
+++ b/src/views/blockDetails/index.tsx
@@ -160,11 +160,17 @@ const BlockDetails = () => {
         selectedTab={selectedTab}
         showMore={showMore}
       />
-      <ExpandButton
-        isExpanded={showMore}
-        itemType={selectedTab}
-        onToggle={handleExpandButtonClick}
-      />
+      {(selectedTab === 'extrinsics' && blockData.body.extrinsics.length > 3)
+        || (selectedTab === 'events' && blockData.body.events.length > 3)
+        ? (
+          <ExpandButton
+            className="-mt-8 font-geist font-body2-bold"
+            isExpanded={showMore}
+            itemType={selectedTab}
+            onToggle={handleExpandButtonClick}
+          />
+        )
+        : null}
       <div className="flex justify-center gap-6 md:hidden">
         {
           subscanLink


### PR DESCRIPTION
This PR improves the block details page by keeping the Extrinsics/Events tabs and the "show more" button fixed outside the scrolling area on mobile.